### PR TITLE
WellKnown: Import initial matrix metadata from matrix.serenityos.org

### DIFF
--- a/.well-known/matrix/client
+++ b/.well-known/matrix/client
@@ -1,0 +1,1 @@
+{"m.homeserver":{"base_url":"https://matrix.serenityos.org:8443/"}}

--- a/.well-known/matrix/server
+++ b/.well-known/matrix/server
@@ -1,0 +1,1 @@
+{"m.server":"matrix.serenityos.org:8443"}

--- a/.well-known/matrix/support
+++ b/.well-known/matrix/support
@@ -1,0 +1,1 @@
+{"contacts":[{"email_address":"networkexception@serenityos.org","matrix_id":"@networkexception:serenityos.org","role":"admin"}]}


### PR DESCRIPTION
This pull request imports the current state of https://matrix.serenityos.org/.well-known/matrix/{server,client,support} into this repository.

Having this on the top level is required for federation to work properly. Before GitHub Actions the webserver had a `301` redirect for `/.well-known/matrix/*` to `matrix.serenityos.org`, since then federation sadly stopped working.

CC: @ADKaster 