### PR TITLE
Add a serenityos.org/discord redirect

### DIFF
--- a/discord/index.html
+++ b/discord/index.html
@@ -1,0 +1,9 @@
+<html>
+<head>
+	<meta http-equiv="refresh" content="0;https://discord.gg/29gCcKsXkF">
+	<title>SerenityOS Discord</title>
+</head>
+<body>
+	<a href="https://discord.gg/29gCcKsXkF">SerenityOS Discord</a>
+</body>
+</html>

--- a/faq/index.html
+++ b/faq/index.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-	<meta http-equiv="refresh" content="1;https://github.com/SerenityOS/serenity/blob/master/Documentation/FAQ.md">
+	<meta http-equiv="refresh" content="0;https://github.com/SerenityOS/serenity/blob/master/Documentation/FAQ.md">
 	<title>SerenityOS FAQ</title>
 </head>
 <body>

--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
 <p><b>Project:</b></p>
 <ul>
     <li><a href="https://github.com/SerenityOS/serenity">SerenityOS on GitHub</a></li>
-    <li><a href="https://discord.gg/serenityos">SerenityOS Discord Server</a> <font color=red>(join here to chat!)</font></li>
+    <li><a href="discord/">SerenityOS Discord Server</a> <font color=red>(join here to chat!)</font></li>
     <li><a href="https://man.serenityos.org">SerenityOS man pages</a></li>
     <li><a href="faq/">Frequently asked questions</a></li>
     <li><a href="bounty/">Bug bounty program</a></li>


### PR DESCRIPTION
This redirect should be more stable than the current discord.gg/serenityos custom invite link.

I also set the FAQ redirect delay to 0 so it matches this new discord redirect. I don't think a delay is necessary here.